### PR TITLE
Fresh start: initial Greedy + subgradient

### DIFF
--- a/cmake/cpp.cmake
+++ b/cmake/cpp.cmake
@@ -524,6 +524,7 @@ foreach(SUBPROJECT IN ITEMS
  lp_data
  packing
  scheduling
+ set_cover
  port
  util)
   add_subdirectory(ortools/${SUBPROJECT})

--- a/ortools/set_cover/CMakeLists.txt
+++ b/ortools/set_cover/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Copyright 2010-2024 Google LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+file(GLOB _SRCS "*.h" "*.cc")
+set(NAME ${PROJECT_NAME}_set_cover)
+
+add_library(${NAME} OBJECT ${_SRCS})
+set_target_properties(${NAME} PROPERTIES
+  CXX_STANDARD 17
+  CXX_STANDARD_REQUIRED ON
+  CXX_EXTENSIONS OFF
+  POSITION_INDEPENDENT_CODE ON)
+target_include_directories(${NAME} PRIVATE
+  ${PROJECT_SOURCE_DIR}
+  ${PROJECT_BINARY_DIR})
+target_link_libraries(${NAME} PRIVATE
+  absl::hash
+  absl::meta
+  absl::memory
+  absl::strings
+  absl::str_format
+  protobuf::libprotobuf
+  ${PROJECT_NAMESPACE}::ortools_proto)

--- a/ortools/set_cover/README.md
+++ b/ortools/set_cover/README.md
@@ -1,0 +1,17 @@
+# Set Cover
+
+This folder serves as a temporary workspace to clearly highlight all files and modifications introduced during the collaboration between Francesco Cavaliere (c4v4) and Google OR-Tools team.
+
+The collaboration focuses on implementing the Set-Covering heuristic (hereafter CFT) described in:
+
+    Caprara, Alberto, Matteo Fischetti, and Paolo Toth. 1999. “A Heuristic
+    Method for the Set Covering Problem.” Operations Research 47 (5): 730–43.
+    https://www.jstor.org/stable/223097
+
+## Notes
+This file also serves as a reference point for discussions on specific aspects of the implementation, especially when there is no better place to document them directly in the code.
+
+- `namespace scp`: Most set-covering related algorithms and data structures use the `SetCover*` prefix. However, for clarity and improved readability, a dedicated namespace could be used.
+- A key aspect of the CFT algorithm is managing the core vs. full model. The algorithm routinely operates on a small subset of columns (core model), refining the selection using reduced costs as a quality proxy. From past experience, correctly implementing the full/core model distinction is crucial to preventing complexity escalation in the implementation.
+- It would be beneficial to standardize the naming conventions for Subset/Column and Element/Row. While the literature often prefers Column/Row, Subset/Element may better reflect the problem's interpretation. Choosing one convention and using it consistently would enhance clarity.
+

--- a/ortools/set_cover/set_cover_cft.h
+++ b/ortools/set_cover/set_cover_cft.h
@@ -1,0 +1,240 @@
+// Copyright 2025 Francesco Cavaliere
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CAV_OR_TOOLS_ORTOOLS_SET_COVER_SET_COVER_CFT_H
+#define CAV_OR_TOOLS_ORTOOLS_SET_COVER_SET_COVER_CFT_H
+
+#include <absl/base/internal/pretty_function.h>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "ortools/algorithms/set_cover_model.h"
+#include "ortools/base/accurate_sum.h"
+#include "ortools/base/strong_vector.h"
+
+namespace operations_research::scp {
+
+////////////////////////////////////////////////////////////////////////
+////////////////////////// COMMON DEFINITIONS //////////////////////////
+////////////////////////////////////////////////////////////////////////
+
+// Mappings to translate btween models with different indices.
+using SubsetMapVector = util_intops::StrongVector<SubsetIndex, SubsetIndex>;
+using ElementMapVector = util_intops::StrongVector<ElementIndex, ElementIndex>;
+using Model = SetCoverModel;
+
+class Solution {
+ public:
+  double cost() const { return cost_; }
+  const std::vector<SubsetIndex>& subsets() const { return subsets_; }
+  void AddSubset(SubsetIndex subset, Cost cost) {
+    subsets_.push_back(subset);
+    cost_ += cost;
+  }
+  bool Empty() const { return subsets_.empty(); }
+  void Clear() {
+    cost_ = 0.0;
+    subsets_.clear();
+  }
+
+ private:
+  Cost cost_;
+  std::vector<SubsetIndex> subsets_;
+};
+
+class DualState {
+ public:
+  DualState(const Model& model);
+  Cost lower_bound() const { return lower_bound_.Value(); }
+  const ElementCostVector& multipliers() const { return multipliers_; }
+  const SubsetCostVector& reduced_costs() const { return reduced_costs_; }
+  void UpdateMultipliers(const Model& model,
+                         const ElementCostVector& multipliers_delta);
+  void SetMultipliers(const Model& model,
+                      const ElementCostVector& multipliers_delta);
+
+ private:
+  template <typename Op>
+  void DualUpdate(const Model& model, Op multiplier_generator);
+
+ private:
+  AccurateSum<Cost> lower_bound_;
+  ElementCostVector multipliers_;
+  SubsetCostVector reduced_costs_;
+};
+
+struct PrimalDualState {
+  Solution solution;
+  DualState dual_state;
+};
+
+class CoreModel : public Model {
+ public:
+  template <typename... Args>
+  CoreModel(Args&&... args) : Model(std::forward<Args>(args)...) {}
+  virtual bool UpdateCore(PrimalDualState& state) = 0;
+  virtual ~CoreModel() = default;
+};
+
+// In the narrow scope of the CFT subgradient, there are often divisions
+// between non-negative quantities (e.g., to compute a relative gap). In these
+// specific cases, the denominator should always be greater than the
+// numerator. This function checks that.
+inline Cost DivideIfGE0(Cost numerator, Cost denominator) {
+  DCHECK_GE(numerator, .0);
+  if (numerator < 1e-6) {
+    return 0.0;
+  }
+  return numerator / denominator;
+}
+
+absl::Status ValidateModel(const Model& model);
+absl::Status ValidateFeasibleSolution(const Model& model,
+                                      const Solution& solution,
+                                      Cost tolerance = 1e-6);
+
+///////////////////////////////////////////////////////////////////////
+///////////////////////////// SUBGRADIENT /////////////////////////////
+///////////////////////////////////////////////////////////////////////
+
+struct SubgradientContext {
+  const Model& model;
+  const DualState& current_dual_state;
+  const DualState& best_dual_state;
+  const Solution& best_solution;
+  const ElementCostVector& subgradient;
+};
+
+class SubgradientCBs {
+ public:
+  virtual bool ExitCondition(const SubgradientContext&) = 0;
+  virtual absl::Status RunHeuristic(const SubgradientContext&, Solution&) = 0;
+  virtual absl::Status ComputeMultipliersDelta(
+      const SubgradientContext&, ElementCostVector& delta_mults) = 0;
+  virtual ~SubgradientCBs() = default;
+};
+
+class CftSubgradientCBs : public SubgradientCBs {
+ public:
+  static constexpr Cost kTol = 1e-6;
+
+  CftSubgradientCBs(const Model& model);
+  Cost step_size() const { return step_size_; }
+  bool ExitCondition(const SubgradientContext& context) override;
+  absl::Status ComputeMultipliersDelta(const SubgradientContext& context,
+                                       ElementCostVector& delta_mults) override;
+  absl::Status RunHeuristic(const SubgradientContext& context,
+                            Solution& solution) override {
+    solution.Clear();
+    return absl::OkStatus();
+  }
+
+ private:
+  void MakeMinimalCoverageSubgradient(const SubgradientContext& context,
+                                      ElementCostVector& subgradient);
+
+ private:
+  Cost squared_norm_;
+  ElementCostVector direction_;  // stabilized subgradient
+  std::vector<SubsetIndex> lagrangian_solution_;
+
+  // Stopping condition
+  Cost prev_best_lb_;
+  BaseInt max_iter_countdown_;
+  BaseInt exit_test_countdown_;
+  BaseInt exit_test_period_;
+
+  // Step size
+  void UpdateStepSize(Cost lower_bound);
+  Cost step_size_;
+  Cost last_min_lb_seen_;
+  Cost last_max_lb_seen_;
+  BaseInt step_size_update_countdown_;
+  BaseInt step_size_update_period_;
+};
+
+absl::StatusOr<PrimalDualState> SubgradientOptimization(
+    CoreModel& core_model, SubgradientCBs& cbs,
+    const PrimalDualState& init_state);
+
+///////////////////////////////////////////////////////////////////////
+//////////////////////// FULL TO CORE PRICING /////////////////////////
+///////////////////////////////////////////////////////////////////////
+
+// TODO(cava): implement core-model/full-model like in [1]
+class FullToCoreModel : public CoreModel {
+  struct UpdateTrigger {
+    BaseInt countdown;
+    BaseInt period;
+    BaseInt max_period;
+  };
+
+ public:
+  FullToCoreModel(Model&& full_model);
+
+  template <typename... Args>
+  FullToCoreModel(Args&&... args)
+      : FullToCoreModel(Model(std::forward<Args>(args)...)) {}
+
+  bool UpdateCore(PrimalDualState& core_state) override;
+
+ private:
+  void UpdatePricingPeriod(const DualState& full_dual_state,
+                           const PrimalDualState& core_state);
+
+  SubsetMapVector columns_map_;
+  Model full_model_;
+  DualState full_dual_state_;
+
+  BaseInt update_countdown_;
+  BaseInt update_period_;
+  BaseInt update_max_period_;
+};
+
+////////////////////////////////////////////////////////////////////////
+/////////////////////// MULTIPLIERS BASED GREEDY ///////////////////////
+////////////////////////////////////////////////////////////////////////
+
+absl::Status CompleteGreedySolution(const Model& model, Solution& solution);
+absl::Status CompleteGreedySolution(const Model& model,
+                                    const DualState& dual_state,
+                                    Cost cost_cutoff, BaseInt size_cutoff,
+                                    Solution& solution);
+
+///////////////////////////////////////////////////////////////////////
+//////////////////////// THREE PHASE ALGORITHM ////////////////////////
+///////////////////////////////////////////////////////////////////////
+
+class HeuristicCBs : public SubgradientCBs {
+ public:
+  HeuristicCBs() : step_size_(0.1), countdown_(250) {};
+  void set_step_size(Cost step_size) { step_size_ = step_size; }
+  bool ExitCondition(const SubgradientContext& context) override {
+    return --countdown_ <= 0;
+  }
+  absl::Status RunHeuristic(const SubgradientContext& context,
+                            Solution& solution) override;
+  absl::Status ComputeMultipliersDelta(const SubgradientContext& context,
+                                       ElementCostVector& delta_mults) override;
+
+ private:
+  Cost step_size_;
+  BaseInt countdown_;
+};
+
+absl::StatusOr<PrimalDualState> RunThreePhase(
+    CoreModel& model, const Solution& init_solution = {});
+
+}  // namespace operations_research::scp
+
+#endif /* CAV_OR_TOOLS_ORTOOLS_SET_COVER_SET_COVER_CFT_H */


### PR DESCRIPTION
Over the past few weeks, I’ve been rethinking the overall design, considering how the project might evolve in the future, things like parallelism, and techniques to speed up subgradient convergence.  

This PR brings in a first implementation of both the subgradient method and the heuristic phase of the algorithm. It also sets up the structure for column fixing and core-model pricing (though these aren’t implemented yet).

The new files are organized in the `scp` namespace inside a new folder (`ortools/set_cover`). This follows the existing OR-Tools module structure, aside from the current `set_cover_*` files in the `algorithms` folder, which seem to be more of a temporary placement.  

A Couple of Open Questions :
- **Logging:** Right now, only basic logging is in place, and I haven’t used Abseil features yet. I'll need some guidance on the preferred approach for this.  
- **Testing Integration:** I'm still figuring out the best way to integrate the new code for proper testing. At the moment, I’m including the changes in `libortools` and linking them to an external binary for runtime testing.  

Here's how I’m running the 3-Phase:  


```cpp
#include <absl/log/initialize.h>
#include <cstdlib>
#include <iostream>

#include "ortools/algorithms/set_cover_reader.h"
#include "ortools/base/init_google.h"
#include "ortools/set_cover/set_cover_cft.h"

ABSL_FLAG(std::string, instance, "", "SCP instance int RAIL format.");
using namespace operations_research;

int main(int argc, char **argv) {
  InitGoogle(argv[0], &argc, &argv, true);

  scp::FullToCoreModel core_model(ReadOrlibRail(absl::GetFlag(FLAGS_instance)));
  auto result = scp::RunThreePhase(core_model);
  if (!result.ok()) {
    std::cerr << "Error: " << result.status() << '\n';
    return EXIT_FAILURE;
  }

  auto [solution, dual] = result.value();
  std::cout << "Solution:    " << solution.cost() << '\n';
  std::cout << "Lower bound: " << dual.lower_bound() << '\n';

  return EXIT_SUCCESS;
}
```